### PR TITLE
Wagtail 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
      python: 3.8
    - env: TOXENV=py38-dj32-wt51
      python: 3.8
+   - env: TOXENV=py38-dj32-wt52
+     python: 3.8
    - env: TOXENV=py38-dj41-wt41
      python: 3.8
    - env: TOXENV=py38-dj41-wt42
@@ -22,6 +24,8 @@ matrix:
    - env: TOXENV=py38-dj41-wt50
      python: 3.8
    - env: TOXENV=py38-dj41-wt51
+     python: 3.8
+   - env: TOXENV=py38-dj41-wt52
      python: 3.8
    - env: TOXENV=py39-dj32-wt41
      python: 3.9
@@ -31,6 +35,8 @@ matrix:
      python: 3.9
    - env: TOXENV=py39-dj32-wt51
      python: 3.9
+   - env: TOXENV=py39-dj32-wt52
+     python: 3.9
    - env: TOXENV=py39-dj41-wt41
      python: 3.9
    - env: TOXENV=py39-dj41-wt42
@@ -38,6 +44,8 @@ matrix:
    - env: TOXENV=py39-dj41-wt50
      python: 3.9
    - env: TOXENV=py39-dj41-wt51
+     python: 3.9
+   - env: TOXENV=py39-dj41-wt52
      python: 3.9
    - env: TOXENV=py310-dj32-wt41
      python: 3.10
@@ -47,6 +55,8 @@ matrix:
      python: 3.10
    - env: TOXENV=py310-dj32-wt51
      python: 3.10
+   - env: TOXENV=py310-dj32-wt52
+     python: 3.10
    - env: TOXENV=py310-dj41-wt41
      python: 3.10
    - env: TOXENV=py310-dj41-wt42
@@ -54,6 +64,8 @@ matrix:
    - env: TOXENV=py310-dj41-wt50
      python: 3.10
    - env: TOXENV=py310-dj41-wt51
+     python: 3.10
+   - env: TOXENV=py310-dj41-wt52
      python: 3.10
    - env: TOXENV=py311-dj41-wt41
      python: 3.11
@@ -63,10 +75,16 @@ matrix:
      python: 3.11
    - env: TOXENV=py311-dj41-wt51
      python: 3.11
+   - env: TOXENV=py311-dj41-wt52
+     python: 3.11
    - env: TOXENV=py311-dj42-wt50
      python: 3.11
    - env: TOXENV=py311-dj42-wt51
      python: 3.11
+   - env: TOXENV=py311-dj42-wt52
+     python: 3.11
+   - env: TOXENV=py312-dj42-wt52
+     python: 3.12
 install:
 - pip install tox coveralls
 - gem install coveralls-lcov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+------------------
+#. Added tests for Wagtail 5.2
+
 2.1 (2023-10-26)
 ------------------
 #. Added Wagtail 5.1 compatibility.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,10 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{38,39,310}-dj{32,41}-wt{41,42,50,51}
-    py311-dj41-wt{41,42,50,51}
-    py311-dj42-wt{50,51}
+    py{38,39,310}-dj{32,41}-wt{41,42,50,51,52}
+    py311-dj41-wt{41,42,50,51,52}
+    py311-dj42-wt{50,51,52}
+    py312-dj42-wt{52}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Upstream PR: https://github.com/springload/wagtail-django-recaptcha/pull/48/commits

Changes:
- Update test matrix to include Wagtail 5.2