### PR TITLE
Import from django_recaptcha instead of captcha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
-    install_requires=["django-recaptcha"],
+    install_requires=["django-recaptcha>=4"],
     extras_require={
         "testing": testing_extras,
         "docs": documentation_extras,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
+from django_recaptcha.fields import ReCaptchaField
 from django.test import TestCase
 from home.models import TestCaptchaEmailFormField
 
@@ -26,7 +26,7 @@ class WagtailCaptchaFormBuilderTestCase(TestCase):
         self.assertIsInstance(
             generated_fields[WagtailCaptchaFormBuilder.CAPTCHA_FIELD_NAME],
             ReCaptchaField,
-            msg="Captcha field should be an instance of `captcha.fields.ReCaptchaField`.",
+            msg="Captcha field should be an instance of `django_recaptcha.fields.ReCaptchaField`.",
         )
 
     def test_user_defined_fields_are_present(self):

--- a/wagtailcaptcha/forms.py
+++ b/wagtailcaptcha/forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
+from django_captcha.fields import ReCaptchaField
 from wagtail.contrib.forms.forms import FormBuilder
 
 

--- a/wagtailcaptcha/forms.py
+++ b/wagtailcaptcha/forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django_captcha.fields import ReCaptchaField
+from django_recaptcha.fields import ReCaptchaField
 from wagtail.contrib.forms.forms import FormBuilder
 
 


### PR DESCRIPTION
Fixes #12 
This is a clone of @DanielSwain's PR from springload/wagtail-django-recaptcha#50

Context:

> Package namespace renamed!
> 
> The package namespace captcha has been renamed to django_recaptcha to avoid conflicts with other captcha packages.
> 
> [Please see the full CHANGELOG for all changes and upgrade considerations](https://github.com/torchbox/django-recaptcha/blob/62afff4c109cf9b918b4a91e7db5981ff4757842/CHANGELOG.md#400-2023-11-14)
> — https://github.com/torchbox/django-recaptcha/releases/tag/4.0.0