### PR TITLE
Import from django_recaptcha instead of captcha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
-    install_requires=["django-recaptcha"],
+    install_requires=["django-recaptcha>=4"],
     extras_require={
         "testing": testing_extras,
         "docs": documentation_extras,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
+from django_recaptcha.fields import ReCaptchaField
 from django.test import TestCase
 from home.models import TestCaptchaEmailFormField
 
@@ -26,7 +26,7 @@ class WagtailCaptchaFormBuilderTestCase(TestCase):
         self.assertIsInstance(
             generated_fields[WagtailCaptchaFormBuilder.CAPTCHA_FIELD_NAME],
             ReCaptchaField,
-            msg="Captcha field should be an instance of `captcha.fields.ReCaptchaField`.",
+            msg="Captcha field should be an instance of `django_recaptcha.fields.ReCaptchaField`.",
         )
 
     def test_user_defined_fields_are_present(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
 from django.test import TestCase
+from django_recaptcha.fields import ReCaptchaField
 from home.models import TestCaptchaEmailFormField
 
 from wagtailcaptcha.forms import WagtailCaptchaFormBuilder
@@ -26,7 +26,7 @@ class WagtailCaptchaFormBuilderTestCase(TestCase):
         self.assertIsInstance(
             generated_fields[WagtailCaptchaFormBuilder.CAPTCHA_FIELD_NAME],
             ReCaptchaField,
-            msg="Captcha field should be an instance of `captcha.fields.ReCaptchaField`.",
+            msg="Captcha field should be an instance of `django_recaptcha.fields.ReCaptchaField`.",
         )
 
     def test_user_defined_fields_are_present(self):

--- a/tests/testapp/testapp/settings.py
+++ b/tests/testapp/testapp/settings.py
@@ -128,7 +128,7 @@ SECRET_KEY = "4*5e^@2%(h#$*b4=ze_kcdw46-$0z#rrf3661c5(&+x^oj=4)+"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Silence some errors
-SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 try:

--- a/wagtailcaptcha/forms.py
+++ b/wagtailcaptcha/forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
+from django_recaptcha.fields import ReCaptchaField
 from wagtail.contrib.forms.forms import FormBuilder
 
 

--- a/wagtailcaptcha/forms.py
+++ b/wagtailcaptcha/forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from captcha.fields import ReCaptchaField
+from django_captcha.fields import ReCaptchaField
 from wagtail.contrib.forms.forms import FormBuilder
 
 

--- a/wagtailcaptcha/forms.py
+++ b/wagtailcaptcha/forms.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django_captcha.fields import ReCaptchaField
+from django_recaptcha.fields import ReCaptchaField
 from wagtail.contrib.forms.forms import FormBuilder
 
 


### PR DESCRIPTION
Original PR by Nick: https://github.com/torchbox-forks/wagtail-django-recaptcha/pull/13

Fixes #12 
This is a clone of @DanielSwain's PR from springload/wagtail-django-recaptcha#50

Context:

> Package namespace renamed!
> 
> The package namespace captcha has been renamed to django_recaptcha to avoid conflicts with other captcha packages.
> 
> [Please see the full CHANGELOG for all changes and upgrade considerations](https://github.com/torchbox/django-recaptcha/blob/62afff4c109cf9b918b4a91e7db5981ff4757842/CHANGELOG.md#400-2023-11-14)
> — https://github.com/torchbox/django-recaptcha/releases/tag/4.0.0