### PR TITLE
Wagtail 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,83 +7,35 @@ cache:
 matrix:
   # See `Which version combinations to include in Travis test matrix?` in `/docs/README.md`.
   include:
-   - env: TOXENV=py38-dj32-wt41
+   - env: TOXENV=py38-dj42-wt52
      python: 3.8
-   - env: TOXENV=py38-dj32-wt42
+   - env: TOXENV=py38-dj42-wt60
      python: 3.8
-   - env: TOXENV=py38-dj32-wt50
+   - env: TOXENV=py38-dj42-wt61
      python: 3.8
-   - env: TOXENV=py38-dj32-wt51
-     python: 3.8
-   - env: TOXENV=py38-dj32-wt52
-     python: 3.8
-   - env: TOXENV=py38-dj41-wt41
-     python: 3.8
-   - env: TOXENV=py38-dj41-wt42
-     python: 3.8
-   - env: TOXENV=py38-dj41-wt50
-     python: 3.8
-   - env: TOXENV=py38-dj41-wt51
-     python: 3.8
-   - env: TOXENV=py38-dj41-wt52
-     python: 3.8
-   - env: TOXENV=py39-dj32-wt41
+   - env: TOXENV=py39-dj42-wt52
      python: 3.9
-   - env: TOXENV=py39-dj32-wt42
+   - env: TOXENV=py39-dj42-wt60
      python: 3.9
-   - env: TOXENV=py39-dj32-wt50
+   - env: TOXENV=py39-dj42-wt61
      python: 3.9
-   - env: TOXENV=py39-dj32-wt51
-     python: 3.9
-   - env: TOXENV=py39-dj32-wt52
-     python: 3.9
-   - env: TOXENV=py39-dj41-wt41
-     python: 3.9
-   - env: TOXENV=py39-dj41-wt42
-     python: 3.9
-   - env: TOXENV=py39-dj41-wt50
-     python: 3.9
-   - env: TOXENV=py39-dj41-wt51
-     python: 3.9
-   - env: TOXENV=py39-dj41-wt52
-     python: 3.9
-   - env: TOXENV=py310-dj32-wt41
+   - env: TOXENV=py310-dj42-wt52
      python: 3.10
-   - env: TOXENV=py310-dj32-wt42
+   - env: TOXENV=py310-dj42-wt60
      python: 3.10
-   - env: TOXENV=py310-dj32-wt50
+   - env: TOXENV=py310-dj42-wt61
      python: 3.10
-   - env: TOXENV=py310-dj32-wt51
-     python: 3.10
-   - env: TOXENV=py310-dj32-wt52
-     python: 3.10
-   - env: TOXENV=py310-dj41-wt41
-     python: 3.10
-   - env: TOXENV=py310-dj41-wt42
-     python: 3.10
-   - env: TOXENV=py310-dj41-wt50
-     python: 3.10
-   - env: TOXENV=py310-dj41-wt51
-     python: 3.10
-   - env: TOXENV=py310-dj41-wt52
-     python: 3.10
-   - env: TOXENV=py311-dj41-wt41
-     python: 3.11
-   - env: TOXENV=py311-dj41-wt42
-     python: 3.11
-   - env: TOXENV=py311-dj41-wt50
-     python: 3.11
-   - env: TOXENV=py311-dj41-wt51
-     python: 3.11
-   - env: TOXENV=py311-dj41-wt52
-     python: 3.11
-   - env: TOXENV=py311-dj42-wt50
-     python: 3.11
-   - env: TOXENV=py311-dj42-wt51
-     python: 3.11
    - env: TOXENV=py311-dj42-wt52
      python: 3.11
-   - env: TOXENV=py312-dj42-wt52
+   - env: TOXENV=py311-dj42-wt60
+     python: 3.11
+   - env: TOXENV=py311-dj42-wt61
+     python: 3.11
+   - env: TOXENV=py312-dj50-wt52
+     python: 3.12
+   - env: TOXENV=py312-dj50-wt60
+     python: 3.12
+   - env: TOXENV=py312-dj50-wt61
      python: 3.12
 install:
 - pip install tox coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,9 @@ Changelog
 Unreleased
 ----------
 
-- Drop testing for Wagtail version before 4.1
-- Add testing for Wagtail versions 5.2 and 6.0
+- Drop support for Wagtail < 5.2
+- Add testing for Wagtail versions 5.2, 6.0, and 6.1
+- Drop support for Django < 4.2
 
 2.1.1 (2024-01-26)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,13 @@ test-ci: ## Continuous integration test suite.
 	tox
 
 update-test-fixture: ## Update test fixture from the db.
-	python ./tests/testapp/manage.py dumpdata --indent=4 -e contenttypes -e auth.permission -e auth.group -e sessions -e wagtailcore.site -e wagtailcore.pagerevision -e wagtailcore.grouppagepermission -e wagtailimages.rendition -e wagtailcore.collection -e wagtailcore.groupcollectionpermission > tests/testapp/fixtures/test_data.json
+	python ./tests/testapp/manage.py dumpdata --indent=4 \
+	-e contenttypes -e auth.permission -e auth.group -e sessions \
+	-e wagtailcore.site -e wagtailcore.revision -e wagtailcore.grouppagepermission \
+	-e wagtailimages.rendition -e wagtailcore.collection -e wagtailcore.groupcollectionpermission \
+	-e wagtailcore.locale \
+	-e wagtailcore.workflowpage -e wagtailcore.workflowtask -e wagtailcore.task -e wagtailcore.workflow -e wagtailcore.groupapprovaltask \
+	> tests/testapp/home/fixtures/test_data.json
 
 clean-pyc: ## Remove Python file artifacts.
 	find . -name '*.pyc' -exec rm -f {} +

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ testing_extras = [
     "flake8>=5.0.4,<5.1",
     "isort>=5.10.1",
     # For test site
-    "wagtail>=4.1",
+    "wagtail>=5.2",
 ]
 
 # Documentation dependencies
@@ -52,11 +52,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 4",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
         "Topic :: Internet :: WWW/HTTP",

--- a/tests/testapp/home/fixtures/test_data.json
+++ b/tests/testapp/home/fixtures/test_data.json
@@ -1,5 +1,150 @@
 [
 {
+    "model": "wagtailcore.page",
+    "pk": 1,
+    "fields": {
+        "path": "0001",
+        "depth": 1,
+        "numchild": 1,
+        "translation_key": "ea434535-f27e-42e2-b13a-d9ef5e252ef5",
+        "locale": 1,
+        "latest_revision": null,
+        "live": true,
+        "has_unpublished_changes": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "live_revision": null,
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "locked_at": null,
+        "locked_by": null,
+        "title": "Root",
+        "draft_title": "Root",
+        "slug": "root",
+        "content_type": 1,
+        "url_path": "/",
+        "owner": null,
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "latest_revision_created_at": null,
+        "alias_of": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 2,
+    "fields": {
+        "path": "00010001",
+        "depth": 2,
+        "numchild": 2,
+        "translation_key": "2e880da7-c2c1-4043-81fe-9ebc4a1396ee",
+        "locale": 1,
+        "latest_revision": null,
+        "live": true,
+        "has_unpublished_changes": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "live_revision": null,
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "locked_at": null,
+        "locked_by": null,
+        "title": "Welcome to your new Wagtail site!",
+        "draft_title": "Welcome to your new Wagtail site!",
+        "slug": "home",
+        "content_type": 1,
+        "url_path": "/home/",
+        "owner": null,
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "latest_revision_created_at": null,
+        "alias_of": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 3,
+    "fields": {
+        "path": "000100010001",
+        "depth": 3,
+        "numchild": 0,
+        "translation_key": "26a0f864-f02d-43e2-8ae1-8332a337837b",
+        "locale": 1,
+        "latest_revision": null,
+        "live": true,
+        "has_unpublished_changes": false,
+        "first_published_at": "2018-02-08T01:22:27.436Z",
+        "last_published_at": "2018-02-08T01:22:44.239Z",
+        "live_revision": null,
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "locked_at": null,
+        "locked_by": null,
+        "title": "Form",
+        "draft_title": "Form",
+        "slug": "form",
+        "content_type": 34,
+        "url_path": "/home/form/",
+        "owner": 1,
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "latest_revision_created_at": "2018-02-08T01:22:44.211Z",
+        "alias_of": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 4,
+    "fields": {
+        "path": "000100010002",
+        "depth": 3,
+        "numchild": 0,
+        "translation_key": "241bc911-f9cf-45f4-a9d4-2d6be2dc5d8e",
+        "locale": 1,
+        "latest_revision": null,
+        "live": true,
+        "has_unpublished_changes": false,
+        "first_published_at": "2018-02-08T01:23:28.032Z",
+        "last_published_at": "2018-02-08T01:23:28.032Z",
+        "live_revision": null,
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "locked_at": null,
+        "locked_by": null,
+        "title": "Email Form",
+        "draft_title": "Email Form",
+        "slug": "email-form",
+        "content_type": 32,
+        "url_path": "/home/email-form/",
+        "owner": 1,
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "latest_revision_created_at": "2018-02-08T01:23:28.010Z",
+        "alias_of": null
+    }
+},
+{
+    "model": "wagtailcore.pagesubscription",
+    "pk": 1,
+    "fields": {
+        "user": 1,
+        "page": 3,
+        "comment_notifications": false
+    }
+},
+{
     "model": "home.testcaptchaemailformfield",
     "pk": 1,
     "fields": {
@@ -12,6 +157,15 @@
         "default_value": "",
         "help_text": "",
         "page": 4
+    }
+},
+{
+    "model": "home.testcaptchaemailformpage",
+    "pk": 4,
+    "fields": {
+        "to_address": "test@test.com",
+        "from_address": "test@test.com",
+        "subject": "You've got an email!"
     }
 },
 {
@@ -30,10 +184,16 @@
     }
 },
 {
+    "model": "home.testcaptchaformpage",
+    "pk": 3,
+    "fields": {}
+},
+{
     "model": "auth.user",
+    "pk": 1,
     "fields": {
-        "password": "pbkdf2_sha256$36000$pel9rvh66phL$jwiLDWGjnabC9DV3sv0gEZTYPychV9RJ1kNReKjQxJM=",
-        "last_login": "2018-02-08T01:21:44.006Z",
+        "password": "pbkdf2_sha256$720000$fyG2f8OhZSPVZLcK7ORejE$UtAirtmAyEoI3zmP1Y09QBPxU8RfHo+fwJ9NMeAZwSY=",
+        "last_login": "2024-05-16T08:41:06.954Z",
         "is_superuser": true,
         "username": "admin",
         "first_name": "",
@@ -44,148 +204,6 @@
         "date_joined": "2018-02-08T01:21:39.242Z",
         "groups": [],
         "user_permissions": []
-    }
-},
-{
-    "model": "home.testcaptchaformpage",
-    "pk": 3,
-    "fields": {}
-},
-{
-    "model": "home.testcaptchaemailformpage",
-    "pk": 4,
-    "fields": {
-        "to_address": "test@test.com",
-        "from_address": "test@test.com",
-        "subject": "You've got an email!"
-    }
-},
-{
-    "model": "wagtailcore.page",
-    "pk": 1,
-    "fields": {
-        "path": "0001",
-        "depth": 1,
-        "numchild": 1,
-        "title": "Root",
-        "draft_title": "Root",
-        "slug": "root",
-        "content_type": [
-            "wagtailcore",
-            "page"
-        ],
-        "live": true,
-        "has_unpublished_changes": false,
-        "url_path": "/",
-        "owner": null,
-        "seo_title": "",
-        "show_in_menus": false,
-        "search_description": "",
-        "go_live_at": null,
-        "expire_at": null,
-        "expired": false,
-        "locked": false,
-        "first_published_at": null,
-        "last_published_at": null,
-        "latest_revision_created_at": null,
-        "live_revision": null
-    }
-},
-{
-    "model": "wagtailcore.page",
-    "pk": 2,
-    "fields": {
-        "path": "00010001",
-        "depth": 2,
-        "numchild": 2,
-        "title": "Welcome to your new Wagtail site!",
-        "draft_title": "Welcome to your new Wagtail site!",
-        "slug": "home",
-        "content_type": [
-            "wagtailcore",
-            "page"
-        ],
-        "live": true,
-        "has_unpublished_changes": false,
-        "url_path": "/home/",
-        "owner": null,
-        "seo_title": "",
-        "show_in_menus": false,
-        "search_description": "",
-        "go_live_at": null,
-        "expire_at": null,
-        "expired": false,
-        "locked": false,
-        "first_published_at": null,
-        "last_published_at": null,
-        "latest_revision_created_at": null,
-        "live_revision": null
-    }
-},
-{
-    "model": "wagtailcore.page",
-    "pk": 3,
-    "fields": {
-        "path": "000100010001",
-        "depth": 3,
-        "numchild": 0,
-        "title": "Form",
-        "draft_title": "Form",
-        "slug": "form",
-        "content_type": [
-            "home",
-            "testcaptchaformpage"
-        ],
-        "live": true,
-        "has_unpublished_changes": false,
-        "url_path": "/home/form/",
-        "owner": [
-            "admin"
-        ],
-        "seo_title": "",
-        "show_in_menus": false,
-        "search_description": "",
-        "go_live_at": null,
-        "expire_at": null,
-        "expired": false,
-        "locked": false,
-        "first_published_at": "2018-02-08T01:22:27.436Z",
-        "last_published_at": "2018-02-08T01:22:44.239Z",
-        "latest_revision_created_at": "2018-02-08T01:22:44.211Z",
-        "live_revision": null
-    }
-},
-{
-    "model": "wagtailcore.page",
-    "pk": 4,
-    "fields": {
-        "path": "000100010002",
-        "depth": 3,
-        "numchild": 0,
-        "title": "Email Form",
-        "draft_title": "Email Form",
-        "slug": "email-form",
-        "content_type": [
-            "home",
-            "testcaptchaemailformpage"
-        ],
-        "live": true,
-        "has_unpublished_changes": false,
-        "url_path": "/home/email-form/",
-        "owner": [
-            "admin"
-        ],
-        "seo_title": "",
-        "show_in_menus": false,
-        "search_description": "",
-        "go_live_at": null,
-        "expire_at": null,
-        "expired": false,
-        "locked": false,
-        "first_published_at": "2018-02-08T01:23:28.032Z",
-        "last_published_at": "2018-02-08T01:23:28.032Z",
-        "latest_revision_created_at": "2018-02-08T01:23:28.010Z",
-        "live_revision": null
     }
 }
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,8 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{38,39,310}-dj{32,41}-wt{41,42,50,51,52}
-    py310-dj42-wt{50,51,52,60}
-    py311-dj41-wt{41,42,50,51,52}
-    py311-dj42-wt{50,51,52,60}
-    py312-dj42-wt{52,60}
+    py{38,39,310,311}-dj{42}-wt{52,60,61}
+    py{312}-dj{50}-wt{52,60,61}
 
 
 [testenv]
@@ -27,14 +24,11 @@ basepython =
     py312: python3.12
 
 deps =
-    dj32: Django>=3.2,<4.0
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
-    wt41: wagtail>=4.1,<5.0
-    wt50: wagtail>=5.0,<5.1
-    wt51: wagtail>=5.1,<5.2
+    dj50: Django>=5.0,<5.1
     wt52: wagtail>=5.2,<6.0
     wt60: wagtail>=6.0,<6.1
+    wt61: wagtail>=6.1,<6.2
 
 commands =
     make lint


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

# Wagtail 6.1 upgrade check list

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [x] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [x] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [x] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [x] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [x] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [x] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [x] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [x] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [x] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [x] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [x] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [x] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [x] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [x] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [x] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [x] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [x] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [x] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [x] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [x] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [x] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [x] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [x] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [x] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)